### PR TITLE
security: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/dora-release-prod.yml
+++ b/.github/workflows/dora-release-prod.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract GitHub Tag Name
         id: extract_tag


### PR DESCRIPTION
## Summary

Pin `actions/checkout@v4` to full commit SHA. All 6 Magento repos share an identical `dora-release-prod.yml` — same fix applied to each.

| Action | Old ref | Pinned SHA |
|--------|---------|------------|
| `actions/checkout` | `@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |

## Why

Mutable tags (`@v4`) can be silently moved to a different commit. Pinning to SHA ensures CI cannot be hijacked via tag mutation.

## Test plan

- [ ] Verify `dora-release-prod` workflow triggers correctly on next version tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)